### PR TITLE
fix require HTTParty

### DIFF
--- a/NeverBounce.rb
+++ b/NeverBounce.rb
@@ -1,4 +1,4 @@
-require 'HTTParty'
+require 'httparty'
 require 'json';
 
 require './NeverBounce/Errors'


### PR DESCRIPTION
This was causing: 
LoadError: cannot load such file -- HTTParty

changed it to require 'httparty'