### PR TITLE
Percent complete data type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    neverbounce-api (1.0.1)
+    neverbounce-api (1.0.2)
       httparty (~> 0.15)
 
 GEM

--- a/lib/never_bounce/api/response/feature/job_status_fields.rb
+++ b/lib/never_bounce/api/response/feature/job_status_fields.rb
@@ -23,7 +23,7 @@ module NeverBounce; module API; module Response; module Feature
 
         oattr :bounce_estimate, :scalar, type: :float
         oattr :filename, :scalar
-        oattr :percent_complete, :scalar, type: :integer
+        oattr :percent_complete, :scalar, type: :float
 
         oattr :total, :writer
 

--- a/lib/never_bounce/api/version.rb
+++ b/lib/never_bounce/api/version.rb
@@ -1,4 +1,4 @@
 
 module NeverBounce; module API
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end; end

--- a/spec/lib/never_bounce/api_spec.rb
+++ b/spec/lib/never_bounce/api_spec.rb
@@ -3,6 +3,6 @@ require "never_bounce/api/version"
 
 describe NeverBounce::API do
   describe "VERSION" do
-    it { expect(described_class::VERSION).to eq "1.0.1" }
+    it { expect(described_class::VERSION).to eq "1.0.2" }
   end
 end


### PR DESCRIPTION
Fixing an incorrect datatype specified for `percent_complete`. It was expected to be an `int` however the API will return a `float`. When a job is completed or unprocessed this isn't an issue, but during the processing, this incorrect datatype can raise errors.