### PR TITLE
Prevent HTTParty from displaying deprecation warnings

### DIFF
--- a/lib/never_bounce/api/feature/require_attr.rb
+++ b/lib/never_bounce/api/feature/require_attr.rb
@@ -19,7 +19,7 @@ module NeverBounce; module API; module Feature
       # @return [mixed]
       def require_attr(name)
         send(name).tap do |_|
-          raise AttributeError, "Attribute must be set: #{name}" if _.nil?
+          raise AttributeError, "Attribute must be set: #{name}" if _ == nil
         end
       end
     end


### PR DESCRIPTION
We recently upgraded httparty in our project and now our test output is
littered with deprecation warnings like this:

```
[DEPRECATION] HTTParty will no longer override `response#nil?`. This functionality will be removed in future versions. Please, add explicit check `response.body.nil? || response.body.empty?`. For more info refer to: https://github.com/jnunemaker/httparty/issues/568
/Users/magnusvk/.gem/ruby/2.7.2/gems/neverbounce-api-1.2.0/lib/never_bounce/api/feature/require_attr.rb:22:in `block in require_attr'
```

It took me some time to figure out what's going on, but the issue is
that `server_ok` in `NeverBounce::API::Session` calls `require_attr` on
the HTTParty response and then `require_attr` calls `.nil?` on that
HTTParty response object.

This actually all seems fine and I don't think the proposed change in
HTTParty will break things here as the intended purpose of
`require_attr` really just seems to be to check that the response is not
`nil`.

This change here is equivalent to the future behavior after HTTParty
makes its change, and it side-steps the deprecation warning.
