### PR TITLE
Avoid HTTParty deprecation warnings on #nil?

### DIFF
--- a/lib/never_bounce/api/feature/require_attr.rb
+++ b/lib/never_bounce/api/feature/require_attr.rb
@@ -18,8 +18,8 @@ module NeverBounce; module API; module Feature
       # Require attribute to be set. Return attribute value.
       # @return [mixed]
       def require_attr(name)
-        send(name).tap do |_|
-          raise AttributeError, "Attribute must be set: #{name}" if _.nil?
+        send(name).tap do |value|
+          raise AttributeError, "Attribute must be set: #{name}" if value == nil
         end
       end
     end

--- a/spec/lib/never_bounce/api/feature/require_attr_spec.rb
+++ b/spec/lib/never_bounce/api/feature/require_attr_spec.rb
@@ -21,5 +21,18 @@ module NeverBounce; module API; module Feature
       r.a = "a"
       expect(r.b).to eq ["a", "b"]
     end
+
+    it "doesn't trip HTTParty's deprecation warning on #nil?" do
+      request = instance_double(HTTParty::Request, options: {})
+      response = instance_double(Net::HTTPResponse, body: nil, to_hash: {})
+      parsed_block = lambda { nil }
+
+      server_obj = HTTParty::Response.new(request, response, parsed_block)
+
+      r = klass.new
+      r.a = server_obj
+
+      expect { r.b }.not_to output(/DEPRECATION/).to_stderr
+    end
   end
 end; end; end


### PR DESCRIPTION
Fixes #20.

The old version of `HTTParty::Response` implements a custom implementation of `#nil?` that checks various properties of the body and raw response object. However, the project is interested in removing this method so that the class will behave more like other Ruby classes. (See jnunemaker/httparty#568.) In the meantime, they've put in a deprecation warning for anyone relying on the old custom behaviour.

The `neverbounce-api` gem isn't doing anything wrong by calling `#nil?` in the implementation of `#require_attr`, but by bad luck it's running afoul of the deprecation warning.

This PR works around the warning by calling `== nil` instead of `#.nil?` on the attribute's value.